### PR TITLE
Read config from own environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The package can be installed [from Hex](https://hex.pm/package/ex_nominatim) by 
 ```elixir
 def deps do
   [
-    {:ex_nominatim, "~> 1.1.3"}
+    {:ex_nominatim, "~> 2.0"}
   ]
 end
 ```
@@ -46,22 +46,22 @@ By calling the endpoint functions of the `ExNominatim` module you will be hittin
 
 ## Optional configuration and default parameters
 
-In the more likely scenario where you use ExNominatim in your own application (e.g., in a Phoenix application) called `MyApp`, you can override all defaults across all endpoints and then even for each endpoint through your application's configuration, e.g. in the `config/config.exs` file of a Phoenix app. For example:
+In the more likely scenario where you use ExNominatim in your own application (e.g., in a Phoenix application), you can override all defaults across all endpoints and then even for each endpoint through your application's configuration, e.g. in the `config/config.exs` file of a Phoenix app. For example:
 
 ```elixir
-config :my_app, MyApp.ExNominatim,
-  all: [
-    base_url: "http://localhost:8080",
-    force: true,
-    format: "json",
-    process: true,
-    atomize: true
-  ],
-  search: [format: "geocodejson", force: false],
-  reverse: [namedetails: 1],
-  lookup: [],
-  details: [],
-  status: [format: "json"]
+  config :ex_nominatim, ExNominatim,
+    all: [
+      base_url: "http://localhost:8080",
+      force: true,
+      format: "json",
+      process: true,
+      atomize: true
+    ],
+    search: [format: "geocodejson", force: false],
+    reverse: [namedetails: 1],
+    lookup: [],
+    details: [],
+    status: [format: "json"]
 ```
 
 The configuration above has the following effects:

--- a/lib/ex_nominatim.ex
+++ b/lib/ex_nominatim.ex
@@ -22,22 +22,22 @@ defmodule ExNominatim do
   >
   > Please respect the [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim/) when using the public server. To prevent useless requests, it is recommended to not disable request validation.
 
-  **New since v1.1.0:** ExNominatim now takes into account your overarching Elixir application's configuration, as defined using the `Config` module. For example, in the `config/config.exs` file of a Phoenix app called `MyApp`, you can define default values like so:
+  **New since v2.0.0:** ExNominatim can be configured as defined using the `Config` module. You can define default values like so:
 
   ```elixir
-  config :my_app, MyApp.ExNominatim,
-  all: [
-    base_url: "http://localhost:8080",
-    force: true,
-    format: "json",
-    process: true,
-    atomize: true
-  ],
-  search: [format: "geocodejson", force: false],
-  reverse: [namedetails: 1],
-  lookup: [],
-  details: [],
-  status: [format: "json"]
+  config :ex_nominatim, ExNominatim,
+    all: [
+      base_url: "http://localhost:8080",
+      force: true,
+      format: "json",
+      process: true,
+      atomize: true
+    ],
+    search: [format: "geocodejson", force: false],
+    reverse: [namedetails: 1],
+    lookup: [],
+    details: [],
+    status: [format: "json"]
   ```
 
   The configuration above has the following effects:
@@ -133,37 +133,13 @@ defmodule ExNominatim do
   Show the current configuration defaults.
   """
   def get_config() do
-    case Application.fetch_env(app_name(), config_key()) do
+    case Application.fetch_env(:ex_nominatim, ExNominatim) do
       {:ok, config} ->
         Keyword.merge(default_config(), config)
 
       :error ->
         default_config()
     end
-  end
-
-  defp own_name do
-    __MODULE__
-    |> Module.split()
-    |> hd()
-  end
-
-  defp app_name do
-    Mix.Project.config()
-    |> Keyword.get(:app)
-  end
-
-  defp config_key do
-    case [
-      app_name()
-      |> to_string()
-      |> Macro.camelize(),
-      own_name()
-    ] do
-      [own, own] -> [own]
-      [app, own] -> [app, own]
-    end
-    |> Module.safe_concat()
   end
 
   defp default_config do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Nominatim.MixProject do
   def project do
     [
       app: :ex_nominatim,
-      version: "1.1.3",
+      version: "2.0.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
Trying to resolve #1

Dependency on Mix could be removed by moving the configuration for `ex_nominatim` in its own namespace with the module as key.

Is this an acceptable solution from your point of view @waseigo or was there a specific reason that the configuration should be done in the namespace of the user's app?

Edit: Major Version Bump, because change of configuration app and key is a breaking change.