### PR TITLE
Adds `req_cache` config for controlling `Req` cache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ config :my_app, MyApp.ExNominatim,
     force: true,
     format: "json",
     process: true,
-    atomize: true
+    atomize: true,
+    req_cache: true
   ],
   search: [format: "geocodejson", force: false],
   reverse: [namedetails: 1],

--- a/lib/ex_nominatim.ex
+++ b/lib/ex_nominatim.ex
@@ -31,7 +31,8 @@ defmodule ExNominatim do
     force: true,
     format: "json",
     process: true,
-    atomize: true
+    atomize: true,
+    req_cache: true,
   ],
   search: [format: "geocodejson", force: false],
   reverse: [namedetails: 1],
@@ -172,7 +173,8 @@ defmodule ExNominatim do
         base_url: @nominatim_public_api,
         force: false,
         process: true,
-        atomize: true
+        atomize: true,
+        req_cache: true
       ],
       search: [],
       reverse: [format: "geocodejson"],

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -1,0 +1,21 @@
+defmodule ExNominatim.ClientTest do
+  use ExUnit.Case, async: true
+  alias ExNominatim.Client
+
+  describe "prepare/4" do
+    test "supports `req_cache` opts for disabling req caching" do
+      assert {:ok, req} =
+               Client.prepare(:search, %{"key" => "value"}, "http://localhost:1234",
+                 req_cache: false
+               )
+
+      assert req.options[:cache] == false
+
+      # Defaults to true when not specified
+      assert {:ok, req} =
+               Client.prepare(:search, %{"key" => "value"}, "http://localhost:1234")
+
+      assert req.options[:cache] == true
+    end
+  end
+end


### PR DESCRIPTION
Adds `req_cache` as possible config entry for controlling `req` cache attribute.

`Req` [cache attribute](https://hexdocs.pm/req/Req.Steps.html#cache/1-options) expects the user running the process to being able to access its home directory and write in its home folder (in the default config where a different `cache_path` is not specified), this however might not be the case (in my case in a Phoenix application deployed on Fly) and we might want to simply disable the cache.


