### PR TITLE
Fixes hex link and adds hex badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # ExNominatim
 
+[![Hex pm](https://img.shields.io/hexpm/v/ex_nominatim.svg?style=flat)](https://hex.pm/packages/ex_nominatim)
+[![Hexdocs.pm](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/ex_nominatim/)
+
 **ExNominatim** is a full-featured client for the [OpenStreetMap](https://www.openstreetmap.org) [Nominatim API V1](https://nominatim.org/release-docs/latest/api/Overview/), with extensive request validation, robust error-handling and reporting, and user guidance with helpful validation messages.
 
 ## Goals
@@ -22,7 +25,7 @@
 
 ## Installation
 
-The package can be installed [from Hex](https://hex.pm/package/ex_nominatim) by adding `ex_nominatim` to your list of dependencies in `mix.exs`:
+The package can be installed [from Hex](https://hex.pm/packages/ex_nominatim) by adding `ex_nominatim` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do


### PR DESCRIPTION
* Fixes broken hex link pointing to hex page (`package/` instead of `packages/`)
* Adds Hex badges

@waseigo the version published on Github is marked as 1.1.3 but on hex is published as 2.0.0, is that correct?